### PR TITLE
Add possibility to use placeholders in currentClass

### DIFF
--- a/MarkupMenuBuilder.module
+++ b/MarkupMenuBuilder.module
@@ -340,7 +340,7 @@ class MarkupMenuBuilder extends WireData implements Module {
 				$itemLast = $m->isLast || $total - $cnt == 1 ? $o->lastClass . ' ' : '';
 
 				//apply current item class to current page + ancestors if specified for both native and included menu items
-				$itemCurrent = 	$m->isCurrent == 1 ? $o->currentClass . ' ' : '';
+				$itemCurrent = 	$m->isCurrent == 1 ? $this->parsePlaceholders($o->currentClass, wire('pages')->get($m->pagesID)) . ' ' : '';
 
 				$classes = $itemCSSClass . $itemHasChildren . $itemLast . $itemCurrent . $itemFirst;
 				$classes = trim(preg_replace('/\s+/', ' ', $classes));
@@ -858,6 +858,58 @@ class MarkupMenuBuilder extends WireData implements Module {
 		return $this->options;
 
 	}
+	
+	/**
+	* Parse Placeholders
+	* 
+	*
+	* @access private
+	* @param String $tpl String with placeholders to parse
+	* @param Page $page page object
+	* @return String $tpl.
+	*
+	*/
+	protected function parsePlaceholders($tpl, Page $page){
+		// template field tags matching
+		preg_match_all('#\{(.+?)\}#i', $tpl, $matches, PREG_SET_ORDER);
+
+		if(count($matches)){
+			foreach($matches as $match) {
+				$v = $page->get($match[1]);
+				$v_unformatted = $page->getUnformatted($match[1]);
+				$field = $this->fields->get($match[1]);
+
+				// check if it's an image file field and output url
+				if($v instanceof Pageimage) {
+					$field_value = $v->url;
+				} else if($v instanceof Pageimages) {
+					if(count($v)) $field_value = $v->first()->url;
+						else $field_value = '';
+				}
+				// if page object from a page field get its url
+				else if($v instanceof Page){
+					$field_value = $v->url;
+
+				} else if($match[1] == 'created' || $match[1] == 'modified') {
+					$field_value = date($this->options['date_format'], $v);
+
+				// } else if(isset($field->type) && $field->type == "FieldtypeDatetime") {
+				// 	$field_value = date($this->options['date_format'], $v_unformatted);
+
+				} else if($match[1] == "createdUsersID" || $match[1] == "modifiedUsersID") {
+					$field_value = $this->users->get($v)->name;
+
+				} else {
+					$field_value = $v;
+				}
+				$tpl = str_replace($match[0], $field_value, $tpl);
+
+			}
+		}
+		return $tpl;
+
+	}
+
 
 	/**
 	* Throw error or return false.

--- a/MarkupMenuBuilder.module
+++ b/MarkupMenuBuilder.module
@@ -811,7 +811,7 @@ class MarkupMenuBuilder extends WireData implements Module {
 			$itemLast = $count - $n == 0 ? $o->lastClass . ' ' : '';			
 		
 			//check for current items (family tree)
-			$itemCurrent = in_array($child->id, $parentIDs) || $child->id == wire('page')->id ? $o->currentClass . ' ' : '';
+			$itemCurrent = in_array($child->id, $parentIDs) || $child->id == wire('page')->id ? $this->parsePlaceholders($o->currentClass, $child) . ' ' : '';
 		
 			$s = '';
 			//build sub-menus

--- a/MarkupMenuBuilder.module
+++ b/MarkupMenuBuilder.module
@@ -875,9 +875,9 @@ class MarkupMenuBuilder extends WireData implements Module {
 
 		if(count($matches)){
 			foreach($matches as $match) {
-				$v = $page->get($match[1]);
-				$v_unformatted = $page->getUnformatted($match[1]);
-				$field = $this->fields->get($match[1]);
+				$field = explode("->", $match[1]);
+				$v = $page->get($field[0]);
+				$v_unformatted = $page->getUnformatted($field[0]);
 
 				// check if it's an image file field and output url
 				if($v instanceof Pageimage) {
@@ -893,11 +893,11 @@ class MarkupMenuBuilder extends WireData implements Module {
 				} else if($match[1] == 'created' || $match[1] == 'modified') {
 					$field_value = date($this->options['date_format'], $v);
 
-				// } else if(isset($field->type) && $field->type == "FieldtypeDatetime") {
-				// 	$field_value = date($this->options['date_format'], $v_unformatted);
-
 				} else if($match[1] == "createdUsersID" || $match[1] == "modifiedUsersID") {
 					$field_value = $this->users->get($v)->name;
+
+				} else if($v instanceof SelectableOptionArray){
+					$field_value = ($field[1]) ? $v->{$field[1]} : $v;
 
 				} else {
 					$field_value = $v;


### PR DESCRIPTION
proof of concept.
you can now access fields and values from the menuitem page to output these in the menu markup. 
for now this only works in current_class/currentClass, but could/should be extended to other fields. 

```
'current_class' => 'current {option} {option->value} {id} {identifier|name}',
```

shameless copy of parsePlaceholders function from MarkupSimpleNavigation.module (https://github.com/somatonic/MarkupSimpleNavigation/blob/master/MarkupSimpleNavigation.module#L307)