### PR TITLE
Fix issue #25 and add missing variable declaration

### DIFF
--- a/ProcessMenuBuilder.module
+++ b/ProcessMenuBuilder.module
@@ -1359,6 +1359,7 @@ class ProcessMenuBuilder extends Process implements Module {
 								
 				if ($addMenus) {
 						
+						$failed = array();
 						$menus = explode("\n", $addMenus);//convert to an array			
 						
 						//Sanitize and save new menus

--- a/ProcessMenuBuilder.module
+++ b/ProcessMenuBuilder.module
@@ -1747,7 +1747,7 @@ class ProcessMenuBuilder extends Process implements Module {
 					$itemID = (int) $addPages[$i];//sanitize: we need this to be an integer
 
 					//multilingual environments
-					if($language != null) $itemTitle = wire('pages')->get($itemID)->title->getLanguageValue($language);//title of each PW page in this array
+					if($language != null && method_exists(wire('pages')->get($itemID)->title, 'getLanguageValue')) $itemTitle = wire('pages')->get($itemID)->title->getLanguageValue($language);//title of each PW page in this array
 					else $itemTitle = wire('pages')->get($itemID)->title;//title of each PW page in this array
 					if(!$itemTitle) continue;//if no new pages posted, move one...[otherwise one iteration with empty strings is added to array!]
 


### PR DESCRIPTION
Add check for existence of getLanguageValue for title field, which is missing if there is only one language configured in the system, and add a missing variable declaration to avoid throwing an exception when a new menu is added under strict PHP settings.